### PR TITLE
#28/fix: fix the linebreak-style eslint error for Windows

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,5 +22,6 @@ module.exports = {
   ],
   rules: {
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
+    "linebreak-style": ["error", "windows"],
   },
 };


### PR DESCRIPTION
Fix the linebreak-style eslint error for Windows
Before:
![before](https://user-images.githubusercontent.com/5677074/61996206-77a0f480-b09a-11e9-81da-b5c55a6e4c32.JPG)
After:
![after](https://user-images.githubusercontent.com/5677074/61996207-7a9be500-b09a-11e9-9d50-d91165a1683b.JPG)
